### PR TITLE
Default to unicode emojis

### DIFF
--- a/src/app/config/icon_cfg.rs
+++ b/src/app/config/icon_cfg.rs
@@ -21,9 +21,9 @@ impl Default for IconsConfig {
 
 fn get_default_dir_icons() -> HashMap<String, String> {
     let mut icon_map = HashMap::new();
-    icon_map.insert(".git".to_string(), "".to_string());
-    icon_map.insert("node_modules".to_string(), "".to_string());
-    icon_map.insert("default".to_string(), "".to_string());
+    icon_map.insert(".git".to_string(), "📁".to_string());
+    icon_map.insert("node_modules".to_string(), "📁".to_string());
+    icon_map.insert("default".to_string(), "📁".to_string());
 
     icon_map
 }
@@ -31,33 +31,33 @@ fn get_default_dir_icons() -> HashMap<String, String> {
 fn get_default_files_icons() -> HashMap<String, String> {
     let mut icon_map = HashMap::new();
     //GIT
-    icon_map.insert(".gitignore".to_string(), "".to_string());
-    icon_map.insert(".gitmodules".to_string(), "".to_string());
+    icon_map.insert(".gitignore".to_string(), "📄".to_string());
+    icon_map.insert(".gitmodules".to_string(), "📄".to_string());
 
     //PROGRAMMING LANGUAGES
-    icon_map.insert("rs".to_string(), "".to_string());
-    icon_map.insert("cs".to_string(), "".to_string());
-    icon_map.insert("cpp".to_string(), "ﭱ".to_string());
-    icon_map.insert("c".to_string(), "".to_string());
-    icon_map.insert("hpp".to_string(), "".to_string());
-    icon_map.insert("h".to_string(), "".to_string());
-    icon_map.insert("js".to_string(), "".to_string());
-    icon_map.insert("ts".to_string(), "".to_string());
-    icon_map.insert("jsx".to_string(), "".to_string());
-    icon_map.insert("tsx".to_string(), "ﰆ".to_string());
-    icon_map.insert("html".to_string(), "".to_string());
-    icon_map.insert("css".to_string(), "".to_string());
-    icon_map.insert("sass".to_string(), "".to_string());
-    icon_map.insert("toml".to_string(), "".to_string());
-    icon_map.insert("yaml".to_string(), "".to_string());
-    icon_map.insert("php".to_string(), "".to_string());
-    icon_map.insert("py".to_string(), "".to_string());
-    icon_map.insert("rb".to_string(), "".to_string());
-    icon_map.insert("java".to_string(), "".to_string());
-    icon_map.insert("lock".to_string(), "".to_string());
-    icon_map.insert("default".to_string(), "".to_string());
-    icon_map.insert("symlink".to_string(), "".to_string());
-    icon_map.insert("warn".to_string(), "".to_string());
+    icon_map.insert("rs".to_string(), "📄".to_string());
+    icon_map.insert("cs".to_string(), "📄".to_string());
+    icon_map.insert("cpp".to_string(), "📄".to_string());
+    icon_map.insert("c".to_string(), "📄".to_string());
+    icon_map.insert("hpp".to_string(), "📄".to_string());
+    icon_map.insert("h".to_string(), "📄".to_string());
+    icon_map.insert("js".to_string(), "📄".to_string());
+    icon_map.insert("ts".to_string(), "📄".to_string());
+    icon_map.insert("jsx".to_string(), "📄".to_string());
+    icon_map.insert("tsx".to_string(), "📄".to_string());
+    icon_map.insert("html".to_string(), "📄".to_string());
+    icon_map.insert("css".to_string(), "📄".to_string());
+    icon_map.insert("sass".to_string(), "📄".to_string());
+    icon_map.insert("toml".to_string(), "📄".to_string());
+    icon_map.insert("yaml".to_string(), "📄".to_string());
+    icon_map.insert("php".to_string(), "📄".to_string());
+    icon_map.insert("py".to_string(), "📄".to_string());
+    icon_map.insert("rb".to_string(), "📄".to_string());
+    icon_map.insert("java".to_string(), "📄".to_string());
+    icon_map.insert("lock".to_string(), "📄".to_string());
+    icon_map.insert("default".to_string(), "📄".to_string());
+    icon_map.insert("symlink".to_string(), "🎯".to_string());
+    icon_map.insert("warn".to_string(), "📄".to_string());
 
     icon_map
 }


### PR DESCRIPTION
I suggest defaulting to Unicode representations of Folders, Files and Symlinks.
This tackles the case when the users don't have the fonts installed and icons show up garbled:
![image](https://user-images.githubusercontent.com/16443090/150171780-f95809c3-5db5-4ff6-87d6-8895f1b020d8.png)